### PR TITLE
Port over some v2 commands

### DIFF
--- a/src/main/java/io/github/codeutilities/CodeUtilities.java
+++ b/src/main/java/io/github/codeutilities/CodeUtilities.java
@@ -17,6 +17,7 @@ public class CodeUtilities implements ModInitializer {
 
     public static final Logger LOGGER = LogManager.getLogger();
     public static final MinecraftClient MC = MinecraftClient.getInstance();
+    public static final String MOD_NAME = "CodeUtilities";
 
     @Override
     public void onInitialize() {

--- a/src/main/java/io/github/codeutilities/commands/CommandManager.java
+++ b/src/main/java/io/github/codeutilities/commands/CommandManager.java
@@ -29,15 +29,40 @@ public class CommandManager implements Loadable {
 
     @Override
     public void load() {
+    	
+    	// item commands
+    	commands.add(new BreakableCommand());
         commands.add(new DfGiveCommand());
-        commands.add(new UUIDCommand());
-        commands.add(new NodeCommand());
         commands.add(new EditNbtCommand());
-        commands.add(new ScriptsCommand());
+        commands.add(new RelativeLocCommand());
+        commands.add(new UnpackCommand());
         commands.add(new WebviewCommand());
+        
+        // misc commands
+        commands.add(new AfkCommand());
+        commands.add(new CalcCommand());
         commands.add(new NBSCommand());
-        commands.add(new AfkCommnd());
+        commands.add(new NodeCommand());
+        commands.add(new PartnerBracketCommand());
         commands.add(new PingCommand());
+        commands.add(new PJoinCommand());
+        commands.add(new ScriptsCommand());
+        
+        // text commands
+        commands.add(new ActionbarCommand());
+        commands.add(new ColorCommand());
+        commands.add(new CopyTextCommand());
+        commands.add(new SubTitleCommand());
+        commands.add(new TitleCommand());
+        commands.add(new UUIDCommand());
+        
+        
+        
+        
+        
+        
+        
+        
 
         // Example of registering commands with a required df rank
         // rankedCommands.put(new TestCommand(), DFRank.JRHELPER);

--- a/src/main/java/io/github/codeutilities/commands/arguments/PlayerArgumentType.java
+++ b/src/main/java/io/github/codeutilities/commands/arguments/PlayerArgumentType.java
@@ -1,0 +1,40 @@
+package io.github.codeutilities.commands.arguments;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.minecraft.command.CommandSource;
+
+import java.util.concurrent.CompletableFuture;
+
+public class PlayerArgumentType implements ArgumentType<String> {
+
+    public PlayerArgumentType() {
+    }
+
+    public static PlayerArgumentType player() {
+        return new PlayerArgumentType();
+    }
+
+    public String parse(StringReader stringReader) {
+        int i = stringReader.getCursor();
+
+        while (stringReader.canRead() && stringReader.peek() != ' ') {
+            stringReader.skip();
+        }
+
+        return stringReader.getString().substring(i, stringReader.getCursor());
+    }
+
+    public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) {
+        if (context.getSource() instanceof CommandSource) {
+            StringReader stringReader = new StringReader(builder.getInput());
+            stringReader.setCursor(builder.getStart());
+            return CommandSource.suggestMatching(((CommandSource) context.getSource()).getPlayerNames(), builder);
+        } else {
+            return Suggestions.empty();
+        }
+    }
+}

--- a/src/main/java/io/github/codeutilities/commands/arguments/StringListArgumentType.java
+++ b/src/main/java/io/github/codeutilities/commands/arguments/StringListArgumentType.java
@@ -1,0 +1,50 @@
+package io.github.codeutilities.commands.arguments;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.minecraft.command.CommandSource;
+import net.minecraft.text.LiteralText;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+public class StringListArgumentType implements ArgumentType<String> {
+    public static final SimpleCommandExceptionType UNKNOWN_TYPE_EXCEPTION = new SimpleCommandExceptionType(new LiteralText("Unknown type"));
+    private final String[] suggestions;
+
+    public StringListArgumentType(String[] suggestions) {
+        this.suggestions = suggestions;
+    }
+
+    public static StringListArgumentType string(String[] suggestions) {
+        return new StringListArgumentType(suggestions);
+    }
+
+    public String parse(StringReader stringReader) throws CommandSyntaxException {
+        int i = stringReader.getCursor();
+
+        while (stringReader.canRead() && stringReader.peek() != ' ') {
+            stringReader.skip();
+        }
+
+        String string = stringReader.getString().substring(i, stringReader.getCursor());
+        if (!Arrays.asList(this.suggestions).contains(string)) {
+            throw UNKNOWN_TYPE_EXCEPTION.createWithContext(stringReader);
+        }
+
+        return string;
+    }
+
+    public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) {
+        if (context.getSource() instanceof CommandSource) {
+            return CommandSource.suggestMatching(this.suggestions, builder);
+        } else {
+            return Suggestions.empty();
+        }
+    }
+}

--- a/src/main/java/io/github/codeutilities/commands/item/BreakableCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/item/BreakableCommand.java
@@ -1,0 +1,55 @@
+package io.github.codeutilities.commands.item;
+
+import com.mojang.brigadier.CommandDispatcher;
+
+import io.github.codeutilities.CodeUtilities;
+import io.github.codeutilities.commands.Command;
+import io.github.codeutilities.util.chat.ChatType;
+import io.github.codeutilities.util.chat.ChatUtil;
+import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.nbt.NbtCompound;
+
+public class BreakableCommand implements Command {
+
+    public void register(CommandDispatcher<FabricClientCommandSource> cd) {
+    	MinecraftClient mc = CodeUtilities.MC;
+        cd.register(literal("breakable")
+                .executes(ctx -> {
+                    if (mc.player.isCreative()) {
+                        ItemStack item = mc.player.getMainHandStack();
+                        if (item.getItem() != Items.AIR) {
+                            NbtCompound nbt = item.getNbt();
+                            nbt.putBoolean("Unbreakable", false);
+                            item.setNbt(nbt);
+                            mc.interactionManager.clickCreativeStack(item, 36 + mc.player.getInventory().selectedSlot);
+                            ChatUtil.sendMessage("The item you're holding is now breakable!", ChatType.SUCCESS);
+                        } else {
+                            ChatUtil.sendMessage("You need to hold an item in your main hand!", ChatType.FAIL);
+                        }
+                    } else {
+                        return -1;
+                    }
+                    return 1;
+                })
+        );
+    }
+
+    /*
+
+    @Override
+    public String getDescription() {
+        return "[blue]/breakable[reset]\n"
+                + "\n"
+                + "Opposite of /unbreakable - Removes the Unbreakable tag from the item you are holding.";
+    }
+
+    @Override
+    public String getName() {
+        return "/breakable";
+    }
+    */
+}
+

--- a/src/main/java/io/github/codeutilities/commands/item/RelativeLocCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/item/RelativeLocCommand.java
@@ -1,0 +1,144 @@
+package io.github.codeutilities.commands.item;
+
+import java.util.Arrays;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.FloatArgumentType;
+
+import io.github.codeutilities.CodeUtilities;
+import io.github.codeutilities.commands.Command;
+import io.github.codeutilities.commands.arguments.StringListArgumentType;
+import io.github.codeutilities.util.ItemUtil;
+import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtList;
+import net.minecraft.nbt.NbtString;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+public class RelativeLocCommand implements Command {
+
+    private static final String[] TARGET_TYPES = {"selection", "default", "damager", "killer", "victim", "shooter", "projectile"};
+
+    public void register(CommandDispatcher<FabricClientCommandSource> cd) {
+    	MinecraftClient mc = CodeUtilities.MC;
+        cd.register(literal("relativeloc")
+                .then(argument("target", StringListArgumentType.string(TARGET_TYPES))
+                        .then(argument("forwards", FloatArgumentType.floatArg())
+                                .then(argument("upwards", FloatArgumentType.floatArg())
+                                        .then(argument("right", FloatArgumentType.floatArg())
+                                                .then(argument("rot_down", FloatArgumentType.floatArg())
+                                                        .then(argument("rot_right", FloatArgumentType.floatArg())
+                                                                .executes(ctx -> {
+                                                                    if (mc.player.isCreative()) {
+                                                                        String target = ctx.getArgument("target", String.class);
+                                                                        Float forwards = ctx.getArgument("forwards", float.class);
+                                                                        Float upwards = ctx.getArgument("upwards", float.class);
+                                                                        Float right = ctx.getArgument("right", float.class);
+                                                                        Float rot_down = ctx.getArgument("rot_down", float.class);
+                                                                        Float rot_right = ctx.getArgument("rot_right", float.class);
+                                                                        return this.run(target, forwards, upwards, right, rot_down, rot_right);
+                                                                    } else {
+                                                                        return -1;
+                                                                    }
+                                                                })
+                                                        )
+                                                )
+                                        )
+                                )
+                        )
+                )
+        );
+    }
+
+    /*
+    @Override
+    public String getDescription() {
+        return "[blue]/relativeloc <target> <forwards> <upwards> <right> <rot_down> <rot_right>[reset]\n"
+                + "\n"
+                + "Gives you the Relative Location item that you can use in your code."
+                + "[red]Disclaimer[reset]: Relative Locations are deprecated code item that is not recommended to use. Use them on your own risk.";
+    }
+
+    @Override
+    public String getName() {
+        return "/relativeloc";
+    }
+    
+    */
+
+    private int run(String target, float forwards, float upwards, float right, float rot_down, float rot_right) {
+        String[] targetNames = {"Selected Object", "Default", "Damager", "Killer", "Victim", "Shooter", "Projectile"};
+        String finalTarget = targetNames[Arrays.asList(TARGET_TYPES).indexOf(target)];
+
+        NbtCompound publicBukkitNBT = new NbtCompound();
+        NbtCompound itemNBT = new NbtCompound();
+        NbtCompound codeNBT = new NbtCompound();
+        NbtCompound dataNBT = new NbtCompound();
+
+        dataNBT.putString("target", finalTarget);
+        dataNBT.putFloat("forward", forwards);
+        dataNBT.putFloat("up", upwards);
+        dataNBT.putFloat("right", right);
+        dataNBT.putFloat("rot_down", rot_down);
+        dataNBT.putFloat("rot_right", rot_right);
+        codeNBT.put("data", dataNBT);
+
+        codeNBT.putString("id", "r_loc");
+        publicBukkitNBT.putString("hypercube:varitem", codeNBT.toString());
+
+        ItemStack item = new ItemStack(Items.PAPER);
+        itemNBT.put("PublicBukkitValues", publicBukkitNBT);
+
+        itemNBT.putInt("CustomModelData", 500);
+
+        item.setNbt(itemNBT);
+
+        NbtCompound display = new NbtCompound();
+        NbtList lore = new NbtList();
+
+        LiteralText itemName = new LiteralText("Relative Location");
+        itemName.setStyle(Style.EMPTY.withColor(Formatting.GREEN).withItalic(false));
+        display.put("Name", NbtString.of(Text.Serializer.toJson(itemName)));
+
+        LiteralText lore1 = new LiteralText("Target: ");
+        LiteralText lore2 = new LiteralText(finalTarget);
+        lore1.setStyle(Style.EMPTY.withColor(Formatting.GRAY).withItalic(false));
+        lore2.setStyle(Style.EMPTY.withColor(Formatting.WHITE).withItalic(false));
+        lore.add(0, NbtString.of(Text.Serializer.toJson(lore1.append(lore2))));
+
+        lore1 = new LiteralText("Forwards: ");
+        craftLore(forwards, lore, lore1);
+
+        lore1 = new LiteralText("Upwards: ");
+        craftLore(upwards, lore, lore1);
+
+        lore1 = new LiteralText("Right: ");
+        craftLore(right, lore, lore1);
+
+        lore1 = new LiteralText("Rot Down: ");
+        craftLore(rot_down, lore, lore1);
+
+        lore1 = new LiteralText("Rot Right: ");
+        craftLore(rot_right, lore, lore1);
+
+        display.put("Lore", lore);
+        item.getNbt().put("display", display);
+
+        ItemUtil.giveCreativeItem(item, true);
+        return 1;
+    }
+
+    private void craftLore(float upwards, NbtList lore, LiteralText lore1) {
+        LiteralText lore2;
+        lore2 = new LiteralText("" + upwards);
+        lore1.setStyle(Style.EMPTY.withColor(Formatting.GRAY).withItalic(false));
+        lore2.setStyle(Style.EMPTY.withColor(Formatting.WHITE).withItalic(false));
+        lore.add(lore.size(), NbtString.of(Text.Serializer.toJson(lore1.append(lore2))));
+    }
+}

--- a/src/main/java/io/github/codeutilities/commands/item/UnpackCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/item/UnpackCommand.java
@@ -1,0 +1,63 @@
+package io.github.codeutilities.commands.item;
+
+import com.mojang.brigadier.CommandDispatcher;
+
+import io.github.codeutilities.CodeUtilities;
+import io.github.codeutilities.commands.Command;
+import io.github.codeutilities.util.ItemUtil;
+import io.github.codeutilities.util.chat.ChatType;
+import io.github.codeutilities.util.chat.ChatUtil;
+import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.item.ItemStack;
+
+public class UnpackCommand implements Command {
+
+    public void register(CommandDispatcher<FabricClientCommandSource> cd) {
+    	MinecraftClient mc = CodeUtilities.MC;
+        cd.register(literal("unpack")
+                .executes(ctx -> {
+                    if (mc.player.isCreative()) {
+                        ItemStack handItem = mc.player.getMainHandStack();
+                        if (!handItem.getOrCreateNbt().getCompound("BlockEntityTag").isEmpty()) {
+
+                            int items = 0;
+                            for (ItemStack stack : ItemUtil.fromItemContainer(handItem)) {
+                                if (!stack.isEmpty()) {
+                                    items++;
+                                    ItemUtil.giveCreativeItem(stack, true);
+                                }
+                            }
+
+                            if (items == 0) {
+                                ChatUtil.sendMessage("There are no items stored in this container!", ChatType.FAIL);
+                            } else {
+                                if (items == 1) {
+                                    ChatUtil.sendMessage("Unpacked §b" + items + "§r item!", ChatType.SUCCESS);
+                                } else {
+                                    ChatUtil.sendMessage("Unpacked §b" + items + "§r items!", ChatType.SUCCESS);
+                                }
+                            }
+                        } else {
+                            ChatUtil.sendMessage("There are no items stored in this item!", ChatType.FAIL);
+                        }
+                    } else {
+                        return -1;
+                    }
+                    return 1;
+                })
+        );
+    }
+
+    /*
+    @Override
+    public String getDescription() {
+        return "[blue]/unpack[reset]\n\nExtracts the items in a container you are holding.";
+    }
+
+    @Override
+    public String getName() {
+        return "/unpack";
+    }
+    */
+}

--- a/src/main/java/io/github/codeutilities/commands/misc/AfkCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/misc/AfkCommand.java
@@ -12,7 +12,7 @@ import net.minecraft.text.LiteralText;
 import net.minecraft.text.Style;
 import net.minecraft.util.Formatting;
 
-public class AfkCommnd implements Command {
+public class AfkCommand implements Command {
 
     @Override
     public void register(CommandDispatcher<FabricClientCommandSource> cd) {

--- a/src/main/java/io/github/codeutilities/commands/misc/CalcCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/misc/CalcCommand.java
@@ -1,0 +1,133 @@
+package io.github.codeutilities.commands.misc;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+
+import io.github.codeutilities.commands.Command;
+import io.github.codeutilities.util.chat.ChatType;
+import io.github.codeutilities.util.chat.ChatUtil;
+import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
+
+public class CalcCommand implements Command {
+
+    private static int exec(CommandContext<FabricClientCommandSource> ctx) {
+        String exp = ctx.getArgument("exp", String.class);
+
+        try {
+            ChatUtil.sendMessage(exp + " §e=§f " + BigDecimal.valueOf(calc(exp)).toPlainString(), ChatType.SUCCESS);
+        } catch (Exception err) {
+            err.printStackTrace();
+            ChatUtil.sendMessage("Error while calculating §6" + exp, ChatType.FAIL);
+        }
+
+        return 1;
+    }
+
+    public static double calc(String exp) throws Exception {
+        String result = exp.toLowerCase();
+
+        if (result.contains("(")) {
+            int open = -1;
+            int close;
+            int pos = 0;
+            while (pos < result.length()) {
+                if (result.charAt(pos) == '(') {
+                    open = pos;
+                } else if (result.charAt(pos) == ')') {
+                    if (open != -1) {
+                        close = pos;
+
+                        String pre = result.substring(0, open);
+                        String res = String.valueOf(
+                            calcPart(result.substring(open + 1, close)));
+                        String post = result.substring(close + 1);
+
+                        return calc(pre + res + post);
+
+                    } else {
+                        throw new Exception("Invalid Brackets");
+                    }
+                }
+
+                pos++;
+            }
+            throw new Exception("Invalid Brackets");
+        }
+
+        return calcPart(result);
+    }
+
+    public static double calcPart(String exp) {
+        String texp = exp.replaceAll(" ", "");
+        String old = null;
+
+        while (!Objects.equals(old, texp)) {
+            old = texp;
+
+            Matcher powm = Pattern.compile(
+                "(?<n1>-?(\\.\\d+|\\d+\\.\\d+|\\d+))\\^(?<n2>-?(\\.\\d+|\\d+\\.\\d+|\\d+))"
+            ).matcher(texp);
+            Matcher mulm = Pattern.compile(
+                "(?<n1>-?(\\.\\d+|\\d+\\.\\d+|\\d+))(?<e>\\*|\\/|%)(?<n2>-?(\\.\\d+|\\d+\\.\\d+|\\d+))"
+            ).matcher(texp);
+            Matcher addm = Pattern.compile(
+                "(?<n1>-?(\\.\\d+|\\d+\\.\\d+|\\d+))(?<e>\\+|\\-)(?<n2>-?(\\.\\d+|\\d+\\.\\d+|\\d+))"
+            ).matcher(texp);
+
+            if (powm.find()) {
+                double num1 = Double.parseDouble(powm.group("n1"));
+                double num2 = Double.parseDouble(powm.group("n2"));
+                texp = powm.replaceFirst(BigDecimal.valueOf(Math.pow(num1, num2)).toPlainString());
+            } else if (mulm.find()) {
+                double num1 = Double.parseDouble(mulm.group("n1"));
+                double num2 = Double.parseDouble(mulm.group("n2"));
+                if (Objects.equals(mulm.group("e"), "*")) {
+                    texp = mulm.replaceFirst(new BigDecimal(num1 * num2).toPlainString());
+                } else if (Objects.equals(mulm.group("e"), "%")) {
+                    texp = mulm.replaceFirst(new BigDecimal(num1 % num2).toPlainString());
+                } else {
+                    texp = mulm.replaceFirst(new BigDecimal(num1 / num2).toPlainString());
+                }
+
+
+            } else if (addm.find()) {
+                double num1 = Double.parseDouble(addm.group("n1"));
+                double num2 = Double.parseDouble(addm.group("n2"));
+                if (Objects.equals(addm.group("e"), "+")) {
+                    texp = addm.replaceFirst(new BigDecimal(num1 + num2).toPlainString());
+                } else {
+                    texp = addm.replaceFirst(new BigDecimal(num1 - num2).toPlainString());
+                }
+            }
+        }
+
+        return Double.parseDouble(texp);
+    }
+
+    @Override
+    public void register(CommandDispatcher<FabricClientCommandSource> cd) {
+        cd.register(literal("calc")
+            .then(argument("exp", StringArgumentType.greedyString())
+                .executes(CalcCommand::exec)
+            )
+        );
+    }
+
+    /*
+    @Override
+    public String getDescription() {
+        return "[blue]/calc <expression>[reset]\n\nCalculates simple math expressions.";
+    }
+
+    @Override
+    public String getName() {
+        return "/calc";
+    }
+    */
+}

--- a/src/main/java/io/github/codeutilities/commands/misc/PJoinCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/misc/PJoinCommand.java
@@ -1,0 +1,120 @@
+package io.github.codeutilities.commands.misc;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.mojang.brigadier.CommandDispatcher;
+
+import io.github.codeutilities.CodeUtilities;
+import io.github.codeutilities.commands.Command;
+import io.github.codeutilities.commands.arguments.PlayerArgumentType;
+import io.github.codeutilities.event.ReceiveChatEvent;
+import io.github.codeutilities.event.system.EventManager;
+import io.github.codeutilities.util.chat.ChatType;
+import io.github.codeutilities.util.chat.ChatUtil;
+import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
+import net.minecraft.client.MinecraftClient;
+
+public class PJoinCommand implements Command {
+	
+	private boolean awaitingJoin = false;
+
+    @Override
+    public void register(CommandDispatcher<FabricClientCommandSource> cd) {
+    	
+    	MinecraftClient mc = CodeUtilities.MC;
+    	
+    	EventManager.getInstance().register(ReceiveChatEvent.class, (event) -> {
+    		
+            if (this.awaitingJoin) {
+            	
+            	String stripped = event.getMessage().getString();
+            	
+                String msg = stripped.replaceAll("§.", "");
+                if (msg.startsWith("                                       \n")) {
+                    if (msg.contains(" is currently at spawn\n")) {
+                        ChatUtil.sendMessage("This player is not in a plot.", ChatType.FAIL);
+                    } else {
+                        // PLOT ID
+                        Pattern pattern = Pattern.compile("\\[[0-9]+]\n");
+                        Matcher matcher = pattern.matcher(msg);
+                        String id = "";
+                        while (matcher.find()) {
+                            id = matcher.group();
+                        }
+                        id = id.replaceAll("\\[|]|\n", "");
+
+                        String cmd = "/join " + id;
+
+                        if (cmd.matches("/join [0-9]+")) {
+                            mc.player.sendChatMessage(cmd);
+                        } else {
+                            ChatUtil.sendMessage("Error while trying to join the plot.", ChatType.FAIL);
+                        }
+
+                    }
+                    
+                    this.awaitingJoin = false;
+                }
+            }
+            
+    	});
+    	
+    	
+    	
+        cd.register(literal("pjoin")
+                .then(argument("player", PlayerArgumentType.player())
+                        .executes(ctx -> {
+                            try {
+                                return run(CodeUtilities.MC, ctx.getArgument("player", String.class));
+                            } catch (Exception e) {
+                                ChatUtil.sendMessage("Error while attempting to execute the command.", ChatType.FAIL);
+                                e.printStackTrace();
+                                return -1;
+                            }
+                        })
+                )
+        );
+    }
+
+    /*
+    @Override
+    public String getDescription() {
+        return "[blue]/pjoin <player>[reset]\n"
+                + "\n"
+                + "Join the plot the specified player is currently playing.";
+    }
+
+    @Override
+    public String getName() {
+        return "/pjoin";
+    }
+    */
+
+    private int run(MinecraftClient mc, String player) {
+
+        if (player.equals(mc.player.getName().asString())) {
+            ChatUtil.sendMessage("You cannot use this command on yourself!", ChatType.FAIL);
+            return -1;
+        }
+
+        mc.player.sendChatMessage("/locate " + player);
+
+        this.awaitingJoin = true;
+        ChatUtil.sendMessage("Joining the plot §e" + player + "§b is currently playing...", ChatType.INFO_BLUE);
+
+        new Thread(() -> {
+            try {
+                Thread.sleep(2000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            if (this.awaitingJoin) {
+                ChatUtil.sendMessage("Timeout error while trying to join the plot.", ChatType.FAIL);
+            }
+            this.awaitingJoin = false;
+        }).start();
+        return 1;
+    }
+}

--- a/src/main/java/io/github/codeutilities/commands/misc/PartnerBracketCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/misc/PartnerBracketCommand.java
@@ -1,0 +1,166 @@
+package io.github.codeutilities.commands.misc;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+
+import io.github.codeutilities.CodeUtilities;
+import io.github.codeutilities.commands.Command;
+import io.github.codeutilities.util.chat.ChatType;
+import io.github.codeutilities.util.chat.ChatUtil;
+import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
+import net.minecraft.block.Blocks;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.OutlineVertexConsumerProvider;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.state.property.Properties;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3d;
+
+public class PartnerBracketCommand implements Command {
+
+    private static boolean active = false;
+    private static BlockPos p1;
+    private static BlockPos p2;
+
+    private static int exec(CommandContext<FabricClientCommandSource> ctx) {
+        exec();
+        return 1;
+    }
+
+    public static void exec() {
+        if (active) {
+            active = false;
+            ChatUtil.sendMessage("Disabled Bracket view.", ChatType.INFO_BLUE);
+            return;
+        }
+        MinecraftClient mc = CodeUtilities.MC;
+        BlockPos pos = new BlockPos(mc.crosshairTarget.getPos());
+        if (!isPiston(pos)) {
+            if (isPiston(pos.north())) {
+                pos = pos.north();
+            } else if (isPiston(pos.south())) {
+                pos = pos.south();
+            } else if (isPiston(pos.east())) {
+                pos = pos.east();
+            } else if (isPiston(pos.west())) {
+                pos = pos.west();
+            } else if (isPiston(pos.up())) {
+                pos = pos.up();
+            } else if (isPiston(pos.down())) {
+                pos = pos.down();
+            }
+        }
+        if (isPiston(pos)) {
+            boolean north = getDir(pos);
+
+            p1 = pos;
+            p2 = pos;
+
+            int depth = 1;
+
+            for (int i = 0; i < 300; i++) {
+                if (north) {
+                    p2 = p2.north();
+                } else {
+                    p2 = p2.south();
+                }
+
+                if (isPiston(p2)) {
+                    if (getDir(p2) == north) {
+                        depth++;
+                    } else {
+                        depth--;
+                        if (depth == 0) {
+                            active = true;
+                            ChatUtil.sendMessage("Partner Found!", ChatType.SUCCESS);
+                            return;
+                        }
+                    }
+                }
+            }
+
+            ChatUtil.sendMessage("No Partner bracket found", ChatType.FAIL);
+        } else {
+            ChatUtil.sendMessage("You need to look at a piston!", ChatType.FAIL);
+        }
+    }
+
+    private static boolean getDir(BlockPos pos) {
+        return CodeUtilities.MC.world.getBlockState(pos).get(Properties.FACING) == Direction.NORTH;
+    }
+
+    private static boolean isPiston(BlockPos pos) {
+        return CodeUtilities.MC.world.getBlockState(pos).isOf(Blocks.PISTON)
+            || CodeUtilities.MC.world.getBlockState(pos).isOf(Blocks.STICKY_PISTON);
+    }
+
+    @Override
+    public void register(CommandDispatcher<FabricClientCommandSource> cd) {
+    	MinecraftClient mc = CodeUtilities.MC;
+        cd.register(literal("partnerbracket")
+            .executes(PartnerBracketCommand::exec)
+        );
+
+
+        WorldRenderEvents.BEFORE_BLOCK_OUTLINE.register((ctx, outline) -> {
+            if (active) {
+                try {
+
+                    MatrixStack matrix = ctx.matrixStack();
+                    matrix.push();
+                    matrix.scale(1.0005f, 1.0005f, 1.0005f);
+                    Vec3d vec = ctx.camera().getPos();
+
+                    matrix.translate(-vec.x, -vec.y, -vec.z);
+
+                    //TODO: someone should recode this cuz im bad at rendering stuff
+                    matrix.push();
+                    matrix.translate(p1.getX(),p1.getY(),p1.getZ());
+
+                    OutlineVertexConsumerProvider outlineVertexConsumerProvider = mc.getBufferBuilders().getOutlineVertexConsumers();
+                    outlineVertexConsumerProvider.setColor(255, 255, 255, 150);
+
+                    mc.getBlockRenderManager().renderBlockAsEntity(
+                        Blocks.WHITE_STAINED_GLASS.getDefaultState(),
+                        ctx.matrixStack(), outlineVertexConsumerProvider,
+                        16777215,
+                        655360
+                    );
+                    matrix.pop();
+
+                    matrix.push();
+                    matrix.translate(p2.getX(),p2.getY(),p2.getZ());
+                    mc.getBlockRenderManager().renderBlockAsEntity(
+                            Blocks.WHITE_STAINED_GLASS.getDefaultState(),
+                            ctx.matrixStack(), outlineVertexConsumerProvider,
+                            16777215,
+                            655360
+                    );
+
+                    matrix.pop();
+
+                    matrix.pop();
+                } catch (Exception err) {
+                    err.printStackTrace();
+                }
+            }
+            return true;
+        });
+    }
+
+    /*
+    @Override
+    public String getDescription() {
+        return "[blue]/partnerbracket[reset]\n"
+                + "\n"
+                + "Highlights where the end/start of the piston bracket you are looking is.";
+    }
+
+    @Override
+    public String getName() {
+        return "/partnerbracket";
+    }
+    */
+}

--- a/src/main/java/io/github/codeutilities/commands/text/ActionbarCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/text/ActionbarCommand.java
@@ -1,0 +1,55 @@
+package io.github.codeutilities.commands.text;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+
+import io.github.codeutilities.CodeUtilities;
+import io.github.codeutilities.commands.Command;
+import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+
+public class ActionbarCommand implements Command {
+
+    public void register(CommandDispatcher<FabricClientCommandSource> cd) {
+    	MinecraftClient mc = CodeUtilities.MC;
+        reg("previewactionbar",mc,cd);
+        reg("actionbarpreview",mc,cd);
+    }
+
+    /*    
+    @Override
+    public String getDescription() {
+        return "[blue]/previewactionbar [text][reset]\n"
+            + "[blue]/actionbarpreview [text][reset]\n"
+            + "\n"
+            + "Previews the action bar text. If no text is specified, the name of the item you are holding will show up.";
+    }
+
+    @Override
+    public String getName() {
+        return "/previewactionbar";
+    }
+     */
+
+
+    public void reg(String name, MinecraftClient mc, CommandDispatcher<FabricClientCommandSource> cd) {
+        cd.register(literal(name)
+            .then(argument("message", StringArgumentType.greedyString())
+                .executes(ctx -> {
+                    Text msg = new LiteralText(
+                        ctx.getArgument("message", String.class)
+                            .replace("&", "§"));
+
+                    mc.player.sendMessage(msg, true);
+                    return 1;
+                })
+            )
+            .executes(ctx -> {
+                mc.player.sendMessage(mc.player.getMainHandStack().getName(),true);
+                return 1;
+            })
+        );
+    }
+}

--- a/src/main/java/io/github/codeutilities/commands/text/ColorCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/text/ColorCommand.java
@@ -1,0 +1,112 @@
+package io.github.codeutilities.commands.text;
+
+import java.awt.Color;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+
+import io.github.codeutilities.CodeUtilities;
+import io.github.codeutilities.commands.Command;
+import io.github.codeutilities.util.chat.ChatType;
+import io.github.codeutilities.util.chat.ChatUtil;
+import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.HoverEvent;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Style;
+import net.minecraft.text.TextColor;
+
+public class ColorCommand implements Command {
+
+    public void register(CommandDispatcher<FabricClientCommandSource> cd) {
+        cd.register(literal("color")
+                /*
+                .then(ArgBuilder.literal("pick")).executes((context -> {
+                    ColorPickerMenu colorPickerMenu = new ColorPickerMenu();
+                    colorPickerMenu.openAsync(colorPickerMenu);
+                    return 1; //TODO command for the menu?
+                }))
+                 */
+                .then(literal("rgb")
+                        .then(argument("r", IntegerArgumentType.integer(0, 255))
+                                .then(argument("g", IntegerArgumentType.integer(0, 255)).
+                                        then(argument("b", IntegerArgumentType.integer(0, 255)).executes((context) -> {
+
+                                            int r = context.getArgument("r", Integer.class);
+                                            int g = context.getArgument("g", Integer.class);
+                                            int b = context.getArgument("b", Integer.class);
+
+                                            copyColor(new Color(r, g, b));
+                                            return 1;
+
+                                        })))
+                        ))
+                .then(literal("hex")
+                        .then(argument("color", StringArgumentType.greedyString()).executes((context) -> {
+                            String color = context.getArgument("color", String.class);
+                            Color hex;
+                            try {
+                                hex = Color.decode(color);
+                            } catch (NumberFormatException e) {
+                                ChatUtil.sendMessage("Invalid Hex!", ChatType.FAIL);
+                                return -1;
+                            }
+                            copyColor(hex);
+                            return 1;
+                        })))
+                .then(literal("hsb")
+                        .then(argument("h", IntegerArgumentType.integer(0, 360))
+                                .then(argument("s", IntegerArgumentType.integer(0, 360)).
+                                        then(argument("b", IntegerArgumentType.integer(0, 360)).executes((context) -> {
+
+                                            float h = context.getArgument("h", Integer.class) / 360.0f;
+                                            float s = context.getArgument("s", Integer.class) / 360.0f;
+                                            float b = context.getArgument("b", Integer.class) / 360.0f;
+
+                                            copyColor(Color.getHSBColor(h, s, b));
+                                            return 1;
+                                        })))
+                        )));
+
+    }
+    
+    /*
+    @Override
+    public String getDescription() {
+        return "[blue]/color rgb <r> <g> <b>[reset]\n"
+            + "[blue]/color hex <hex>[reset]\n"
+            + "[blue]/color hsb <h> <s> <b>[reset]\n"
+            + "\n"
+            + "Copies the specified color in DiamondFire hex color format.\n"
+            + "The max number is [green]256[reset] for RGB colors, and [green]360[reset] for HSB colors.\n"
+            + "[yellow]Example[reset]: /color 255 0 0 -> &x&f&f&0&0&0&0";
+    }
+
+    @Override
+    public String getName() {
+        return "/color";
+    }
+    */
+
+
+    private void copyColor(Color color) {
+        String colorName = Integer.toHexString(color.getRGB()).substring(2);
+
+        String colorNameReal = "#" + Integer.toHexString(color.getRGB()).substring(2);
+        Style colorStyle = Style.EMPTY.withColor(TextColor.fromRgb(color.getRGB()));
+
+        LiteralText text = new LiteralText("Copied Color! ");
+        LiteralText preview = new LiteralText("█");
+        LiteralText hover = new LiteralText(colorNameReal);
+        hover.append("\n§7Click to copy!");
+        hover.setStyle(colorStyle);
+        preview.styled((style) -> style.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/color hex " + colorNameReal)));
+        preview.styled((style) -> style.withHoverEvent(HoverEvent.Action.SHOW_TEXT.buildHoverEvent(hover)));
+
+        
+        
+        CodeUtilities.MC.keyboard.setClipboard("&x&" + String.join("&", colorName.split("")));
+        ChatUtil.sendMessage(text.append(ChatUtil.setColor(preview, color)), ChatType.INFO_BLUE);
+    }
+}

--- a/src/main/java/io/github/codeutilities/commands/text/CopyTextCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/text/CopyTextCommand.java
@@ -1,0 +1,38 @@
+package io.github.codeutilities.commands.text;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+
+import io.github.codeutilities.CodeUtilities;
+import io.github.codeutilities.commands.Command;
+import io.github.codeutilities.util.chat.ChatType;
+import io.github.codeutilities.util.chat.ChatUtil;
+import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
+
+public class CopyTextCommand implements Command {
+
+    public void register(CommandDispatcher<FabricClientCommandSource> cd) {
+        cd.register(literal("copytxt")
+                .then(argument("text", StringArgumentType.greedyString())
+                        .executes(ctx -> {
+                            CodeUtilities.MC.keyboard.setClipboard(ctx.getArgument("text", String.class));
+                            ChatUtil.sendMessage("Copied text!", ChatType.INFO_BLUE);
+                            return 1;
+                        })
+                )
+        );
+    }
+    
+    /*
+    @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+    */
+
+}

--- a/src/main/java/io/github/codeutilities/commands/text/SubTitleCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/text/SubTitleCommand.java
@@ -1,0 +1,61 @@
+package io.github.codeutilities.commands.text;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+
+import io.github.codeutilities.CodeUtilities;
+import io.github.codeutilities.commands.Command;
+import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+
+public class SubTitleCommand implements Command {
+
+    public void register(CommandDispatcher<FabricClientCommandSource> cd) {
+    	MinecraftClient mc = CodeUtilities.MC;
+        reg("previewsubtitle",mc,cd);
+        reg("subtitlepreview",mc,cd);
+    }
+    
+    /*
+
+    @Override
+    public String getDescription() {
+        return "[blue]/previewsubtitle [text][reset]\n"
+                + "[blue]/subtitlepreview [text][reset]\n"
+                + "\n"
+                + "Previews the sub-title text. If no text is specified, the name of the item you are holding will show up.";
+    }
+
+    @Override
+    public String getName() {
+        return "/previewsubtitle";
+    }
+    
+    */
+
+    public void reg(String name, MinecraftClient mc, CommandDispatcher<FabricClientCommandSource> cd) {
+        cd.register(literal(name)
+            .then(argument("message", StringArgumentType.greedyString())
+                .executes(ctx -> {
+                    Text msg = new LiteralText(
+                        ctx.getArgument("message", String.class)
+                            .replace("&", "§"));
+
+                    mc.inGameHud.setTitle(new LiteralText("§c"));
+                    mc.inGameHud.setSubtitle(msg);
+                    mc.inGameHud.setTitleTicks(20, 60, 20);
+                    return 1;
+                })
+            )
+            .executes(ctx -> {
+                mc.inGameHud.setTitle(new LiteralText("§c"));
+                mc.inGameHud.setSubtitle(mc.player.getMainHandStack().getName());
+                mc.inGameHud.setTitleTicks(20, 60, 20);
+                
+                return 1;
+            })
+        );
+    }
+}

--- a/src/main/java/io/github/codeutilities/commands/text/TitleCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/text/TitleCommand.java
@@ -1,0 +1,57 @@
+package io.github.codeutilities.commands.text;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+
+import io.github.codeutilities.CodeUtilities;
+import io.github.codeutilities.commands.Command;
+import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+
+public class TitleCommand implements Command {
+
+    @Override
+    public void register(CommandDispatcher<FabricClientCommandSource> cd) {
+    	MinecraftClient mc = CodeUtilities.MC;
+        reg("previewtitle",mc,cd);
+        reg("titlepreview",mc,cd);
+    }
+
+    /*
+    @Override
+    public String getDescription() {
+        return "[blue]/previewtitle [text][reset]\n"
+                + "[blue]/titlepreview [text][reset]\n"
+                + "\n"
+                + "Previews the title text. If no text is specified, the name of the item you are holding will show up.";
+    }
+
+    @Override
+    public String getName() {
+        return "/previewtitle";
+    }
+    */
+
+    public void reg(String name, MinecraftClient mc, CommandDispatcher<FabricClientCommandSource> cd) {
+        cd.register(literal(name)
+            .then(argument("message", StringArgumentType.greedyString())
+                .executes(ctx -> {
+                    Text msg = new LiteralText(
+                        ctx.getArgument("message", String.class)
+                            .replace("&", "§"));
+
+                    mc.inGameHud.setTitle(msg);
+                    mc.inGameHud.setTitleTicks(20, 60, 20);
+                    return 1;
+                })
+            )
+            .executes(ctx -> {
+                mc.inGameHud.setTitle(mc.player.getMainHandStack().getName());
+                mc.inGameHud.setTitleTicks(20, 60, 20);
+                return 1;
+            })
+        );
+    }
+}

--- a/src/main/java/io/github/codeutilities/commands/text/UUIDCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/text/UUIDCommand.java
@@ -43,6 +43,21 @@ public class UUIDCommand implements Command {
                 )
         );
     }
+    
+    /*
+    
+    @Override
+    public String getDescription() {
+        return "[blue]/uuid <username>[reset]\n"
+            + "\n"
+            + "Copies the uuid of the player to your clipboard and if you're in dev mode also gives you the uuid as a text item.";
+    }
+
+    @Override
+    public String getName() {
+        return "/uuid";
+    }
+    */
 
     private void showUUID(String uuid) {
         if (uuid == null) {

--- a/src/main/java/io/github/codeutilities/util/ItemUtil.java
+++ b/src/main/java/io/github/codeutilities/util/ItemUtil.java
@@ -1,9 +1,15 @@
 package io.github.codeutilities.util;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.github.codeutilities.CodeUtilities;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtList;
 import net.minecraft.util.collection.DefaultedList;
 
 public class ItemUtil {
@@ -40,4 +46,49 @@ public class ItemUtil {
         MinecraftClient mc = CodeUtilities.MC;
         mc.interactionManager.clickCreativeStack(item, mc.player.getInventory().selectedSlot + 36);
     }
-}
+    
+    public static List<ItemStack> fromListTag(NbtList listTag) {
+        List<ItemStack> stacks = new ArrayList<>();
+        for (NbtElement tag : listTag) {
+            stacks.add(ItemStack.fromNbt((NbtCompound) tag));
+        }
+        return stacks;
+    }
+
+	public static void giveCreativeItem(ItemStack item, boolean preferHand) {
+        MinecraftClient mc = CodeUtilities.MC;
+        DefaultedList<ItemStack> mainInventory = mc.player.getInventory().main;
+
+        if (preferHand) {
+            if (mc.player.getMainHandStack().isEmpty()) {
+                mc.interactionManager.clickCreativeStack(item, mc.player.getInventory().selectedSlot + 36);
+                return;
+            }
+        }
+
+        for (int index = 0; index < mainInventory.size(); index++) {
+            ItemStack i = mainInventory.get(index);
+            ItemStack compareItem = i.copy();
+            compareItem.setCount(item.getCount());
+            if (item == compareItem) {
+                while (i.getCount() < i.getMaxCount() && item.getCount() > 0) {
+                    i.setCount(i.getCount() + 1);
+                    item.setCount(item.getCount() - 1);
+                }
+            } else {
+                if (i.getItem() == Items.AIR) {
+                    if (index < 9)
+                        mc.interactionManager.clickCreativeStack(item, index + 36);
+                    mainInventory.set(index, item);
+                    return;
+                	}
+            	}
+        	}
+    	}
+
+	public static List<ItemStack> fromItemContainer(ItemStack container) {
+        NbtList nbt = container.getOrCreateNbt().getCompound("BlockEntityTag").getList("Items", 10);
+        return fromListTag(nbt);
+    }
+	
+	}


### PR DESCRIPTION
Went through and ported over a bunch of the simpler v2 commands. I've left the names and descriptions commented out, as I'm not sure how to register those with the new system or lack thereof.

Some other files have been touched, like adding necessary argument types and fixing a typo in AfkCommand

I didn't bring over anything with UI (not enough experience) or config (seems like it's a WIP).

List of everything I brought over:
- Breakable
- RelativeLoc
- Unpack
- Calc
- PartnerBracket
- PJoin
- Actionbar
- Color
- CopyText
- SubTitle
- Title

In testing, the only discrepancy I've currently noticed is PartnerBracket - the blocks appear solid white rather than a piece of stained glass.

Let me know if anything needs to be changed.